### PR TITLE
Fix time zone error

### DIFF
--- a/app/domain/models/contributions/repositories/appraisal.rb
+++ b/app/domain/models/contributions/repositories/appraisal.rb
@@ -56,8 +56,8 @@ module CodePraise
           appraisal: odm.document['appraisal'],
           state: odm.document['state'],
           request_id: odm.document['request_id'],
-          created_at: odm.document['created_at'],
-          updated_at: odm.document['updated_at']
+          created_at: odm.document['created_at'].localtime('+08:00'),
+          updated_at: odm.document['updated_at'].localtime('+08:00')
         )
       end
     end


### PR DESCRIPTION
1. Set time zone as GMT +8 for the time retrieve from MongoDB